### PR TITLE
Fix licence typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# D2 Coding 글꼴
+﻿# D2 Coding 글꼴
 [![Github All Releases](https://img.shields.io/github/downloads/naver/d2codingfont/total.svg)](https://github.com/naver/d2codingfont)
 
 ### 다운로드 
@@ -30,6 +30,6 @@ D2 Coding 글꼴은 나눔바른고딕을 바탕으로 개발자의 코딩을 �
 ## 라이센스  
 '누구나 사용'할 수 있고 또 OFL 라이센스 하에서 '누구나 재배포' 하실 수 있습니다.
 
-D2 Coding 글꼴은 OFL(Open Font License)이라는 국제적으로 인정받는 공개 글꼴을 위한 라이센스를 채택하여 사용에 대한 제약을 없앰과 동시에 재배포에 대한 제약도 획기적으로 완화하여, 이 라이센스를 명시하기만 하면 다른 프로그램(상용 프로그램 포함)에 이 개발자용 나눔고딕코딩체를 포함하여 재배포하는 것도 허용합니다. 
+D2 Coding 글꼴은 OFL(Open Font License)이라는 국제적으로 인정받는 공개 글꼴을 위한 라이센스를 채택하여 사용에 대한 제약을 없앰과 동시에 재배포에 대한 제약도 획기적으로 완화하여, 이 라이센스를 명시하기만 하면 다른 프로그램(상용 프로그램 포함)에 이 개발자용 D2 Coding 글꼴을 포함하여 재배포하는 것도 허용합니다. 
 
 자세한 사항은 아래 [OpenFontLicense](https://github.com/naver/d2codingfont/wiki/Open-Font-License)를 참고하세요~


### PR DESCRIPTION
라이센스에 '나눔고딕코딩체를' 이라고 잘못 표기되어 있던 것을 'D2 Coding 글꼴을' 으로 수정하였습니다.